### PR TITLE
Add mysqldb support

### DIFF
--- a/oboe/__init__.py
+++ b/oboe/__init__.py
@@ -96,6 +96,9 @@ class OboeConfig(object):
         self._config['inst']['memcache'] = defaultdict(lambda: True)
         self._config['inst']['memcache']['collect_backtraces'] = False
 
+        self._config['inst']['mysqldb'] = defaultdict(lambda: True)
+        self._config['inst']['mysqldb']['collect_backtraces'] = True
+
         self._config['inst']['pymongo'] = defaultdict(lambda: True)
         self._config['inst']['pymongo']['collect_backtraces'] = True
 
@@ -847,9 +850,9 @@ def _Event_addInfo_safe(func):
     return wrapped
 
 def sample_request(layer, xtr, avw):
-        
+
     rv = SwigContext.sampleRequest(layer, xtr or '', avw or '')
-    
+
     # For older binding to liboboe that returns true/false, just return that.
     if rv.__class__ == bool or (rv == 0):
       return rv

--- a/oboeware/inst_mysqldb.py
+++ b/oboeware/inst_mysqldb.py
@@ -1,0 +1,33 @@
+""" Tracelytics instrumentation for python-MySQLdb
+
+ Copyright (C) 2014 AppNeta, Inc.
+ All rights reserved.
+"""
+import oboe
+
+def wrap_do_query(func, f_args, _f_kwargs, _return_val):
+    # TODO: can't figure out how to get Database without state tracking
+    return { 'RemoteHost': f_args[0]._get_db().get_host_info().split(' ')[0],
+             'Query': f_args[1] }
+
+def wrap(module, cursors):
+    """ wrap MySQLdb methods of interest """
+    cls = getattr(cursors, 'BaseCursor', None)
+    decorate = oboe.log_method('mysqldb',
+                   store_backtrace=oboe._collect_backtraces('mysqldb'),
+                   callback=wrap_do_query)
+    if cls:
+        # _do_query underlies both execute and executemany
+        method = getattr(cls, '_do_query', None)
+        if method:
+            setattr(cls, '_do_query', decorate(method))
+    else:
+        print >> sys.stderr, "Oboe error: failed to find BaseCursor"
+
+
+try:
+    import MySQLdb as mdb_module
+    import MySQLdb.cursors as mdb_cursors
+    wrap(mdb_module, mdb_cursors)
+except ImportError, e:
+    pass

--- a/oboeware/loader.py
+++ b/oboeware/loader.py
@@ -12,14 +12,16 @@ def _enabled(m):
     return oboe.config['inst_enabled'][m]
 
 def load_inst_modules():
-    if _enabled('memcache'):
-        from oboeware import inst_memcache
-    if _enabled('pymongo'):
-        from oboeware import inst_pymongo
-    if _enabled('sqlalchemy'):
-        from oboeware import inst_sqlalchemy
     if _enabled('httplib'):
         from oboeware import inst_httplib
+    if _enabled('memcache'):
+        from oboeware import inst_memcache
+    if _enabled('mysqldb'):
+        from oboeware import inst_mysqldb
+    if _enabled('pymongo'):
+        from oboeware import inst_pymongo
     if _enabled('redis'):
         from oboeware import inst_redis
+    if _enabled('sqlalchemy'):
+        from oboeware import inst_sqlalchemy
     # additionally, in djangoware.py: 'django_orm', 'django_templates'

--- a/test/unit/test_mysqldb.py
+++ b/test/unit/test_mysqldb.py
@@ -1,0 +1,75 @@
+"""Test MySQLdb instrumentation"""
+
+import base
+import MySQLdb
+from oboeware import inst_mysqldb # pylint: disable-msg=W0611
+import os
+import trace_filters as f
+import unittest2 as unittest
+
+
+MYSQL_HOST = os.environ.get('OBOE_MYSQL_HOST', 'localhost')
+MYSQL_USER = os.environ.get('OBOE_MYSQL_USER', 'testuser')
+MYSQL_PASS = os.environ.get('OBOE_MYSQL_PASS', None)
+MYSQL_DB = os.environ.get('OBOE_MYSQL_DB', 'test_db')
+
+is_mysqldb_layer = f.prop_is('Layer', 'mysqldb')
+
+class TestMySQLdb(base.TraceTestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestMySQLdb, self).__init__(*args, **kwargs)
+
+    def _connect(self):
+        return MySQLdb.connect(host=MYSQL_HOST, user=MYSQL_USER, passwd=MYSQL_PASS, db=MYSQL_DB)
+
+    def assertIsQuery(self, **props):
+        """ Checks for a basic Query span construct; any provided KV args will be
+            checked for inclusion in exit event. """
+        self.print_events()
+
+        entry = self._last_trace.pop_events(f.is_entry_event, is_mysqldb_layer)
+        self.assertEqual(1, len(entry))
+
+        exit_props = [f.is_exit_event, is_mysqldb_layer]
+        if props:
+            for k,v in props.iteritems():
+                exit_props.append(f.prop_is(k, v))
+
+        exit = self._last_trace.pop_events(*exit_props)
+        self.assertEqual(1, len(exit))
+
+    def test_execute(self):
+        """ Test cursor.execute() """
+        query = "select 1"
+        with self.new_trace():
+            db = self._connect()
+            c = db.cursor()
+            c.execute(query);
+        self.assertIsQuery(Query=query, RemoteHost=MYSQL_HOST)
+
+    def test_executemany_and_errors(self):
+        """ Test cursor.executemany(), also tests that errors work. """
+        query = """INSERT INTO breakfast (name, spam, eggs, sausage, price)
+                  VALUES (%s, %s, %s, %s, %s)"""
+        vals = [ ("Spam and Sausage Lover's Plate", 5, 1, 8, 7.95 ) ]
+
+        with self.new_trace():
+            db = self._connect()
+            reported_query = query % tuple(db.literal(v) for v in vals[0])
+
+            c = db.cursor()
+            try:
+                c.executemany(query, vals);
+            except Exception, e:
+                print e
+
+        # query vals
+        self.assertIsQuery(Query=reported_query, RemoteHost=MYSQL_HOST)
+
+        # error: table 'breakfast' does not exist
+        error = self._last_trace.pop_events(f.label_is('error'),
+                                            f.prop_is('ErrorClass', 'ProgrammingError'))
+        self.assertEqual(1, len(error))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds support for python-mysqldb query execution tracing and obfuscation.

dkuebric - This is the one it's tested against: http://mysql-python.sourceforge.net/ --  there are competing alternatives here--possibly many!

One thing is that mysql-python follows the python dbapi spec. I think this instrumentation may cover only methods that are part of that spec. That means we may be able to generalize this instrumentation to cover any python module that implements the dbapi for a particular database.

So, not to scope creep this, but that might be a future or present possibility...