### PR TITLE
Do not fail if endEvt is None

### DIFF
--- a/oboeware/middleware.py
+++ b/oboeware/middleware.py
@@ -125,16 +125,17 @@ class OboeMiddleware(object):
                 result = self.wrapped_app(environ, wrapped_start_response)
 
         except Exception:
-            if oboe.Context.get_default().is_valid():
-                endEvt.add_edge(oboe.Context.get_default())
-            self.send_end(ctx, endEvt, environ, threw_error=True)
+            if endEvt:
+                if oboe.Context.get_default().is_valid():
+                    endEvt.add_edge(oboe.Context.get_default())
+                self.send_end(ctx, endEvt, environ, threw_error=True)
             raise
 
-        # check current TLS context and add to end event if valid
-        if oboe.Context.get_default().is_valid():
-            endEvt.add_edge(oboe.Context.get_default())
-
-        self.send_end(ctx, endEvt, environ, stats=stats)
+        if endEvt:
+            # check current TLS context and add to end event if valid
+            if oboe.Context.get_default().is_valid():
+                endEvt.add_edge(oboe.Context.get_default())
+            self.send_end(ctx, endEvt, environ, stats=stats)
 
         return result
 


### PR DESCRIPTION
This fixes a behaviour I've seen in this module when integrating with TurboGears and CherryPy.
An exception is raise because endEvt is false. This happens at the first request received by the application (but only at the first request).
I suspect the context starts as invalid, thus endEvt is not defined, but then becomes valid during runapp().

This proposed change fixes this behaviour. It might not produce a valid trace, but will avoid the library crashing.